### PR TITLE
Resolve LLaVA Training Checkpoint Bug

### DIFF
--- a/LLaVA-Gemma/llava/train/llava_trainer.py
+++ b/LLaVA-Gemma/llava/train/llava_trainer.py
@@ -273,8 +273,8 @@ class LLaVATrainer(Trainer):
             if self.args.local_rank == 0 or self.args.local_rank == -1:
                 self.model.config.save_pretrained(output_dir)
                 torch.save(weight_to_save, os.path.join(output_dir, f'mm_projector.bin'))
-        else:
-            super(LLaVATrainer, self)._save_checkpoint(model, trial, metrics)
+
+        super(LLaVATrainer, self)._save_checkpoint(model, trial, metrics)
 
     def _save(self, output_dir: Optional[str] = None, state_dict=None):
         if getattr(self.args, 'tune_mm_mlp_adapter', False):


### PR DESCRIPTION
- When LLaVATrainer:_save_checkpoint is called it did not finish by calling the super _save_checkpoint (GaudiTrainer:_save_checkpoint). This was resulting in an invalid checkpoint.

Error message when trying to resume from checkpoint without this fix:
```bash
Last 10 lines of StdErr:
  File "/train/train_mem.py", line 13, in <module>
    train()
  File "//train/train.py", line 1295, in train
    trainer.train(resume_from_checkpoint=True)
  File "/transformers/trainer.py", line 1850, in train
    state = TrainerState.load_from_json(os.path.join(resume_from_checkpoint, TRAINER_STATE_NAME))
  File "/transformers/trainer_callback.py", line 148, in load_from_json
    with open(json_path, "r", encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: './work_dirs/llava/checkpoint-1000/trainer_state.json'
```